### PR TITLE
feat: Re-arrange Trainings

### DIFF
--- a/data/en/formations.yml
+++ b/data/en/formations.yml
@@ -1,7 +1,7 @@
 enable  : true
 topTitle:
 title   : trainings.
-subtitle : Through our training courses, we help you comprehend the landscape of Cloud Native technologies. Our courses are all [Open Source](https://github.com/particuleio/formations).
+subtitle : Through our training courses, we help you comprehend the landscape of Cloud Native technologies. Our courses are all [Open Source](https://github.com/particuleio/formations). All our training courses can be customized to match your needs and your expectations.
 
 item  :
   - name        : Kubernetes

--- a/data/en/formations.yml
+++ b/data/en/formations.yml
@@ -4,41 +4,38 @@ title   : trainings.
 subtitle : Through our training courses, we help you comprehend the landscape of Cloud Native technologies. Our courses are all [Open Source](https://github.com/particuleio/formations).
 
 item  :
-  - name        : Kubernetes User
+  - name        : Kubernetes
     price       : 3 days
-    description : Getting started with the API and prepare CKAD exam
+    description : "Kubernetes training for Kubernetes administors and users"
     featurelist :
       - item: Kubernetes concepts
       - item: Main API objects
       - item: Design and deploy applications
-      - item: Best practices
-      - item: Prepare [CKAD exam](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_V1.18.pdf)
-    btnText     : Contact Us
-    btnURL      : "https://particule.io/en#contact"
-    color       : kubernetes
-
-  - name        : Kubernetes Operator
-    price       : 3 days
-    description : Deploy and manage Kubernetes clusters
-    featurelist :
       - item: Where to deploy and how ?
+      - item: Network
+      - item: Storage
       - item: Deployment tools
       - item: Cluster operation and hardening
       - item: Main admin API objects
-      - item: Prepare [CKA exam](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_V1.18.pdf)
+      - item: User and operator training
+      - item: Prepare [CKA](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_v1.19.pdf) et [CKAD exam](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_V1.19.pdf)
     btnText     : Contact Us
     btnURL      : "https://particule.io/en#contact"
     color       : kubernetes
 
-  - name        : Kubernetes - AIO
-    price       : 5 days
-    description : "All in one : operator and user trainings"
+  - name        : Kubernetes Security
+    price       : 2 jours
+    description : Build and operate Kubernetes with security concerns in mind
     featurelist :
-      - item: User and operator training
-      - item: Prepare [CKA](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_V1.18.pdf) et [CKAD exam](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_V1.18.pdf)
-    btnText     : Contact Us
-    btnURL      : "https://particule.io/en#contact"
-    color       : kubernetes
+      - item: "Prerequisite : Kubernetes course"
+      - item: Container Runtime
+      - item: RBAC management
+      - item: PKI Kubernetes
+      - item: Network security
+      - item: Pods security
+      - item: Prepare [CKS](https://github.com/cncf/curriculum/blob/master/CKS_Curriculum_%20v1.19.pdf)
+    btnText     : Nous contacter
+    btnURL      : "https://particule.io#contact"
 
   - name        : Terraform
     price       : 3 days

--- a/data/fr/formations.yml
+++ b/data/fr/formations.yml
@@ -1,7 +1,7 @@
 enable  : true
 topTitle:
 title   : formations.
-subtitle : Nous vous aidons, au travers de nos formations, à appréhender les technologies Cloud Native. Nos supports de formations sont entièrement [Open Source](https://github.com/particuleio/formations).
+subtitle : Nous vous aidons, au travers de nos formations, à appréhender les technologies Cloud Native. Nos supports de formations sont entièrement [Open Source](https://github.com/particuleio/formations). Toutes nos formations peuvent faire l'objet d'une personnalisation selon vos besoins et vos attentes.
 imgSocialNetwork: images/og/container-runtime.png
 
 item  :

--- a/data/fr/formations.yml
+++ b/data/fr/formations.yml
@@ -5,41 +5,37 @@ subtitle : Nous vous aidons, au travers de nos formations, à appréhender les t
 imgSocialNetwork: images/og/container-runtime.png
 
 item  :
-  - name        : Kubernetes Utilisateur
+  - name        : Kubernetes
     price       : 3 jours
-    description : Se familiariser avec les API et préparer le CKAD
+    description : "Formation Kubernetes abordant les aspects d'administration et d'utilisation"
     featurelist :
       - item: Découverte des concepts
-      - item: Les principaux objets de l'API
+      - item: Les principaux objets de l’API
       - item: Concevoir et déployer des applications
-      - item: Bonnes pratiques
-      - item: Préparation certification [CKAD](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_V1.18.pdf)
-      - item: Support de cours [HTML](https://particule.io/formations/kubernetes-user.fr.html)/[PDF](https://particule.io/formations/kubernetes-user.fr.html?print-pdf)
-    btnText     : Nous contacter
-    btnURL      : "https://particule.io#contact"
-    color       : kubernetes
-
-  - name        : Kubernetes Opérateur
-    price       : 3 jours
-    description : Déployer et administrer un cluster Kubernetes
-    featurelist :
+      - item: Le stockage
+      - item: Le réseau
       - item: Où déployer ? Comment ?
       - item: Les différents outils de déploiements
-      - item: Opérer et sécuriser un cluster
-      - item: Les principaux objets admin de l'API
-      - item: Préparation certification [CKA](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_V1.18.pdf)
-      - item: Support de cours [HTML](https://particule.io/formations/kubernetes-ops.fr.html)/[PDF](https://particule.io/formations/kubernetes-ops.fr.html?print-pdf)
+      - item: Opérer un cluster
+      - item: Les principaux objets admin de l’API
+      - item: Prépare au [CKA](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_v1.19.pdf) et [CKAD](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_V1.19.pdf)
+      - item: Support de cours [HTML](https://particule.io/formations/kubernetes-full.fr.html)/[PDF](https://particule.io/formations/kubernetes-full.fr.html?print-pdf)
     btnText     : Nous contacter
     btnURL      : "https://particule.io#contact"
     color       : kubernetes
 
-  - name        : Kubernetes - AIO
-    price       : 5 jours
-    description : "All in one : formations utilisateur et opérateur"
+  - name        : Kubernetes Sécurité
+    price       : 2 jours
+    description : Formation Kubernetes avancé sur les aspects de sécurité
     featurelist :
-      - item: Combine la formation utilisateur et opérateur
-      - item: Prépare au [CKA](https://github.com/cncf/curriculum/blob/master/CKA_Curriculum_V1.18.pdf) et [CKAD](https://github.com/cncf/curriculum/blob/master/CKAD_Curriculum_V1.18.pdf)
-      - item: Support de cours [HTML](https://particule.io/formations/kubernetes-full.fr.html)/[PDF](https://particule.io/formations/kubernetes-full.fr.html?print-pdf)
+      - item: "Prérequis : formation Kubernetes"
+      - item: Container Runtime
+      - item: Gestion des RBAC
+      - item: PKI Kubernetes
+      - item: Sécurité du réseau
+      - item: Sécurité des pods
+      - item: Prépare au [CKS](https://github.com/cncf/curriculum/blob/master/CKS_Curriculum_%20v1.19.pdf)
+      - item: Support de cours [HTML](https://particule.io/formations/kubernetes-security.fr.html)/[PDF](https://particule.io/formations/kubernetes-security.fr.html?print-pdf)
     btnText     : Nous contacter
     btnURL      : "https://particule.io#contact"
     color       : kubernetes


### PR DESCRIPTION
Hey ! 

I propose to drop the Kubernetes dev/ops courses. We don't really want them because you can't really do a training for just one of them. So that leaves us with just a Kubernetes course.

I also propose a new course about Kubernetes security to prepare people for the CKS certification